### PR TITLE
fixups

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -19,8 +19,8 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
@@ -361,9 +361,9 @@ func TestInspectionDisabledAnnotation(t *testing.T) {
 }
 
 func makeReconcileInfo(host *metal3v1alpha1.BareMetalHost) *reconcileInfo {
-	return &reconcileInfo {
-	log:     logf.Log.WithName("controllers").WithName("BareMetalHost").WithName("baremetal_controller"),
-	host:    host,
+	return &reconcileInfo{
+		log:  logf.Log.WithName("controllers").WithName("BareMetalHost").WithName("baremetal_controller"),
+		host: host,
 	}
 }
 
@@ -374,7 +374,7 @@ func TestHasRebootAnnotation(t *testing.T) {
 
 	hasReboot, rebootMode := hasRebootAnnotation(info)
 	assert.False(t, hasReboot)
-	assert.Equal(t, rebootMode, metal3v1alpha1.RebootMode(""))
+	assert.Equal(t, metal3v1alpha1.RebootModeSoft, rebootMode)
 
 	host.Annotations = make(map[string]string)
 	suffixedAnnotation := rebootAnnotationPrefix + "/foo"
@@ -382,20 +382,20 @@ func TestHasRebootAnnotation(t *testing.T) {
 
 	hasReboot, rebootMode = hasRebootAnnotation(info)
 	assert.True(t, hasReboot)
-	assert.Equal(t, rebootMode, metal3v1alpha1.RebootModeSoft)
+	assert.Equal(t, metal3v1alpha1.RebootModeSoft, rebootMode)
 
 	delete(host.Annotations, suffixedAnnotation)
 	host.Annotations[rebootAnnotationPrefix] = ""
 
 	hasReboot, rebootMode = hasRebootAnnotation(info)
 	assert.True(t, hasReboot)
-	assert.Equal(t, rebootMode, metal3v1alpha1.RebootModeSoft)
+	assert.Equal(t, metal3v1alpha1.RebootModeSoft, rebootMode)
 
 	host.Annotations[suffixedAnnotation] = ""
 
 	hasReboot, rebootMode = hasRebootAnnotation(info)
 	assert.True(t, hasReboot)
-	assert.Equal(t, rebootMode, metal3v1alpha1.RebootModeSoft)
+	assert.Equal(t, metal3v1alpha1.RebootModeSoft, rebootMode)
 
 	//two suffixed annotations to simulate multiple clients
 
@@ -403,7 +403,7 @@ func TestHasRebootAnnotation(t *testing.T) {
 
 	hasReboot, rebootMode = hasRebootAnnotation(info)
 	assert.True(t, hasReboot)
-	assert.Equal(t, rebootMode, metal3v1alpha1.RebootModeSoft)
+	assert.Equal(t, metal3v1alpha1.RebootModeSoft, rebootMode)
 }
 
 func TestHasHardRebootAnnotation(t *testing.T) {
@@ -413,7 +413,7 @@ func TestHasHardRebootAnnotation(t *testing.T) {
 
 	hasReboot, rebootMode := hasRebootAnnotation(info)
 	assert.False(t, hasReboot)
-	assert.Equal(t, rebootMode, metal3v1alpha1.RebootMode(""))
+	assert.Equal(t, metal3v1alpha1.RebootModeSoft, rebootMode)
 
 	host.Annotations = make(map[string]string)
 	suffixedAnnotation := rebootAnnotationPrefix + "/foo/"
@@ -421,27 +421,27 @@ func TestHasHardRebootAnnotation(t *testing.T) {
 
 	hasReboot, rebootMode = hasRebootAnnotation(info)
 	assert.True(t, hasReboot)
-	assert.Equal(t, rebootMode, metal3v1alpha1.RebootModeHard)
+	assert.Equal(t, metal3v1alpha1.RebootModeHard, rebootMode)
 
 	delete(host.Annotations, suffixedAnnotation)
 	host.Annotations[rebootAnnotationPrefix] = "{\"mode\": \"soft\"}"
 
 	hasReboot, rebootMode = hasRebootAnnotation(info)
 	assert.True(t, hasReboot)
-	assert.Equal(t, rebootMode, metal3v1alpha1.RebootModeSoft)
+	assert.Equal(t, metal3v1alpha1.RebootModeSoft, rebootMode)
 
 	delete(host.Annotations, suffixedAnnotation)
 	host.Annotations[rebootAnnotationPrefix] = "{\"bad\"= \"json\"]"
 
 	hasReboot, rebootMode = hasRebootAnnotation(info)
 	assert.True(t, hasReboot)
-	assert.Equal(t, rebootMode, metal3v1alpha1.RebootModeSoft)
+	assert.Equal(t, metal3v1alpha1.RebootModeSoft, rebootMode)
 
 	host.Annotations[suffixedAnnotation] = ""
 
 	hasReboot, rebootMode = hasRebootAnnotation(info)
 	assert.True(t, hasReboot)
-	assert.Equal(t, rebootMode, metal3v1alpha1.RebootModeSoft)
+	assert.Equal(t, metal3v1alpha1.RebootModeSoft, rebootMode)
 
 	//two suffixed annotations to simulate multiple clients
 
@@ -449,7 +449,7 @@ func TestHasHardRebootAnnotation(t *testing.T) {
 
 	hasReboot, rebootMode = hasRebootAnnotation(info)
 	assert.True(t, hasReboot)
-	assert.Equal(t, rebootMode, metal3v1alpha1.RebootModeHard)
+	assert.Equal(t, metal3v1alpha1.RebootModeHard, rebootMode)
 }
 
 // TestRebootWithSuffixlessAnnotation tests full reboot cycle with suffixless


### PR DESCRIPTION
Change isHardReboot to getRebootMode so the controller code can just
pass the result to the provisioner.

Swap the order of arguments to assert.Equal() to place the expected
value in the right spot.

Fix a couple of tests that were expecting an empty string for the
reboot mode, since that value should never be an empty string.

Signed-off-by: Doug Hellmann <dhellmann@redhat.com>